### PR TITLE
[bg #159054013] Fix delete response message

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -218,8 +218,8 @@ class ArticleAPIView(mixins.CreateModelMixin,
         else:
             raise PermissionDenied(
                 'You do not have permission to delete this article')
-
-        return Response(None, status=status.HTTP_204_NO_CONTENT)
+        message = {"Success": "Article deleted successfully"}
+        return Response(message, status=status.HTTP_204_NO_CONTENT)
 
 
 class CommentsListCreateAPIView(generics.ListCreateAPIView):


### PR DESCRIPTION
**What does this PR do?**
Fixes bug on delete article response

**Background information**
The message returned wasn't descriptive enough.

**How To Manually Test?**
`Pull ft-create-articles-159054013`
`git pull origin ft-create-articles-159054013`

- Update database by running migrations.
`python manage.py makemigrations`
`python manage.py migrate`

- Run test coverage
`python manage.py test`

- Start the server
`python manage.py runserver`

- Test the endpoints on postman.

Affected Endpoints:
DELETE /api/articles/<slug>/
Response:
```
{
    "article": {
        "Success": "Article deleted successfully"
    }
}
```
Screenshot:
<img width="1280" alt="screen shot 2018-08-13 at 18 51 02" src="https://user-images.githubusercontent.com/18376530/44042854-0b5b901e-9f2a-11e8-96bb-3417c7324c1e.png">

**Relevant Pivotal tracker stories**
[#159054013](https://www.pivotaltracker.com/story/show/159054013) User should be able to create articles
