### PR TITLE
#59054021 Fix Ratings Bug.

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -85,25 +85,6 @@ class ArticleSerializer(serializers.ModelSerializer):
     def get_dislikes_count(self, obj):
         return obj.dislikes.count()
 
-
-class RateSerializer(serializers.Serializer):
-    """Serializers registration requests and creates a new rate."""
-
-    rate = serializers.IntegerField(required=True)
-
-    def validate(self, data):
-        """Check that rate is valid"""
-        rating = data.get('rate')
-        if rating == '':
-            raise serializers.ValidationError('Rate is required.')
-        # Validate the rate is between 0 and 5.
-        if rating < 0 or rating > 5:
-            raise serializers.ValidationError(
-                'Rate should be from 0 to 5.')
-
-        return {"rate": rating}
-
-
 class CommentSerializer(serializers.ModelSerializer):
     """Handles serialization and deserialization of Comments objects."""
     author = ProfileSerializer(required=False)

--- a/authors/apps/articles/tests/test_ratings.py
+++ b/authors/apps/articles/tests/test_ratings.py
@@ -142,7 +142,7 @@ class RateTestCase(APITestCase):
                                     auth_user["user"]["token"],
                                     format='json'
                                     )
-        self.assertEquals(res.data["errors"]["message"][0], "You are only allowed torate 3 times")
+        self.assertEquals(res.data["errors"]["message"][0], "You are only allowed to rate 3 times")
         self.assertEquals(res.status_code, 403)
 
     def test_rate_should_be_a_number(self):

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -110,7 +110,7 @@ class RateAPIView(CreateAPIView):
         # If exist check if the user has exceed rating counter
         if rating.counter > 3:
             """Allow rating if counter is less than 3."""
-            return Response({"errors": {"message": ["You are only allowed to"
+            return Response({"errors": {"message": ["You are only allowed to "
                                                     "rate 3 times"]}}, status=status.HTTP_403_FORBIDDEN)
 
         rating.ratings = rate


### PR DESCRIPTION
**What does this PR do?**
Fixes bug on rating response
Also get rid of duplicate rating serializer.

**Background information**
The message returned had a grammatical error.

**How To Manually Test?**
`fetch origin`
`git checkout bg-rating-159816402`

- Update database by running migrations.
`python manage.py migrate`

- Run test coverage
`python manage.py test`

- Start the server
`python manage.py runserver`

- Test the endpoints on postman.

Affected Endpoints:
DELETE /api/articles/<slug>/rate/
Response:
```
{
    "rate": {
        "response": {
            "message": [
                "Successfull."
            ],
            "avg_ratings": {
                "ratings__avg": 4
            }
        }
    }
}
```
Screenshot:
<img width="1261" alt="screen shot 2018-08-16 at 10 04 08" src="https://user-images.githubusercontent.com/19705477/44193809-bf09cb80-a13c-11e8-87c8-73a932fdf9a3.png">


**Relevant Pivotal tracker stories**
[#159816402](https://www.pivotaltracker.com/story/show/159816402) Fix ratings bug.
