### PR TITLE
#160399755 Update sign-in error message

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -121,7 +121,7 @@ class LoginSerializer(serializers.Serializer):
         # `authenticate` will return `None`. Raise an exception in this case.
         if user is None:
             raise serializers.ValidationError(
-                'A user with this email and password was not found.'
+                'A user with this email or password was not found.'
             )
 
         # Django provides a flag on our `User` model called `is_active`. The


### PR DESCRIPTION
**What does this PR do?**
Updates a response message when a user provides incorrect credentials.

**Background information**
The message returned had `AND` instead of `OR`.

**How To Manually Test?**
`fetch origin`
`ch-signin-error-message-160399755`

- Update database by running migrations.
`python manage.py migrate`

- Run test coverage
`python manage.py test`

- Start the server
`python manage.py runserver`

- Test the endpoints on postman.

Affected Endpoints:
DELETE /api/users/login/
Response:
```
{
    "errors": {
        "error": [
            "A user with this email or password was not found."
        ]
    }
}
```
Screenshot:
<img width="1006" alt="screen shot 2018-09-10 at 22 45 20" src="https://user-images.githubusercontent.com/19705477/45320673-fc9b2200-b54b-11e8-9377-3b25d294572d.png">


**Relevant Pivotal tracker stories**
[#160399755](https://www.pivotaltracker.com/story/show/160399755) .
