### PR TITLE
#160439992 Add email field on user's profile

### DIFF
--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -5,13 +5,15 @@ from .models import Profile
 
 class ProfileSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')
-    get_notifications = serializers.BooleanField(source='user.get_notifications')
+    email = serializers.CharField(source='user.email')
+    get_notifications = serializers.BooleanField(
+        source='user.get_notifications')
     bio = serializers.CharField(allow_blank=True, required=False)
     image = serializers.SerializerMethodField()
 
     class Meta:
         model = Profile
-        fields = ('username', 'bio', 'image','get_notifications',)
+        fields = ('username', 'email', 'bio', 'image', 'get_notifications',)
         read_only_fields = ('username',)
 
     def get_image(self, obj):
@@ -19,4 +21,3 @@ class ProfileSerializer(serializers.ModelSerializer):
             return obj.image
 
         return 'https://static.productionready.io/images/smiley-cyrus.jpg'
-


### PR DESCRIPTION
**What does this PR do?**
Updates the user profile section as it introduces an email field

**Background information**
The user profile did not have an email field

**How To Manually Test?**
`fetch origin`
`bg-profile-email-160439992`

- Run test
`coverage run manage.py test`

- Start the server
`python manage.py runserver`

- Test the endpoints on postman.

Affected Endpoints:
GET /api/profiles/:username/
Response:
```
{
    "profile": {
        "username": "testuser",
        "email": "testuser@gmail.com",
        "bio": "",
        "image": "https://static.productionready.io/images/smiley-cyrus.jpg",
        "get_notifications": true
    }
}
```
Screenshot:
![image](https://user-images.githubusercontent.com/25982160/45402268-7969f100-b65d-11e8-97ec-3c68ef0a72a4.png)

**Relevant Pivotal tracker stories**
[#160439992](https://www.pivotaltracker.com/story/show/160439992) .
